### PR TITLE
Resolves #20 - Export Sisp class on index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+const Sisp = require('./src/sisp');
+
+module.exports = Sisp;

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,12 @@
+const Sisp = require('./index');
+
+describe('index', () => {
+  it('should be exported correctly', () => {
+    const sisp = new Sisp({
+      posID: 900512,
+      posAutCode: '123456789ssA'
+    });
+
+    expect(sisp).toBeDefined();
+  });
+});


### PR DESCRIPTION
The Sisp class should be exported in index.js.
because it is our application entry point, and this will provide more flexibility in the future to export others classes