### PR TITLE
Resolves #25 - Include organization name on the package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sisp_payments",
+  "name": "@chuva.io/sisp_payments",
   "version": "1.0.0",
   "description": "This module simplifies getting started with processing Vinti4, Visa, and Mastercard payments using SISP on Node.js.",
   "main": "./src/index.js",


### PR DESCRIPTION
### Description
To publish the package in the organization account we need to include organization name on the package.json file.

`  "name": "@chuva.io/sisp_payments"`

[NPM Docs](https://docs.npmjs.com/creating-and-publishing-an-organization-scoped-package)